### PR TITLE
model save/load refactored, get_layer created

### DIFF
--- a/tensorlayer/models/core.py
+++ b/tensorlayer/models/core.py
@@ -688,7 +688,7 @@ class Model():
                 format = 'hdf5'
 
         if format == 'hdf5' or format == 'h5':
-            utils.save_weights_to_hdf5(filepath, self.weights)
+            utils.save_weights_to_hdf5(filepath, self)
         elif format == 'npz':
             utils.save_npz(self.weights, filepath)
         elif format == 'npz_dict':
@@ -761,10 +761,10 @@ class Model():
         if format == 'hdf5' or format == 'h5':
             if skip == True or in_order == False:
                 # load by weights name
-                utils.load_hdf5_to_weights(filepath, self.weights, skip)
+                utils.load_hdf5_to_weights(filepath, self, skip)
             else:
                 # load in order
-                utils.load_hdf5_to_weights_in_order(filepath, self.weights)
+                utils.load_hdf5_to_weights_in_order(filepath, self)
         elif format == 'npz':
             utils.load_and_assign_npz(filepath, self)
         elif format == 'npz_dict':

--- a/tensorlayer/models/core.py
+++ b/tensorlayer/models/core.py
@@ -538,6 +538,40 @@ class Model():
     def all_drop(self):
         raise Exception("all_drop is deprecated")
 
+    def get_layer(self, name=None, index=None):
+        """Network forwarding given input tensors
+
+        Parameters
+        ----------
+        name : str or None
+            Name of the requested layer. Default None.
+        index : int or None
+            Index of the requested layer. Default None.
+
+        Returns
+        -------
+            layer : The requested layer
+
+        Notes
+        -----
+        Either a layer name or a layer index should be given.
+
+        """
+        if index is not None:
+            if len(self.all_layers) <= index:
+                raise ValueError('model only has ' + str(len(self.all_layers)) +
+                                 ' layers, but ' + str(index) + '-th layer is requested.')
+            else:
+                return self.all_layers[index]
+        elif name is not None:
+            for layer in self.all_layers:
+                if layer.name == name:
+                    return layer
+            raise ValueError('Model has no layer named ' + name + '.')
+        else:
+            raise ValueError('Either a layer name or a layer index should be given.')
+
+
     def _construct_graph(self):
         """construct computation graph for static model using LayerNode object"""
         all_layers = []
@@ -731,7 +765,7 @@ class Model():
         Examples
         --------
         1) load model from a hdf5 file.
-        >>> net = tl.model.vgg16()
+        >>> net = tl.models.vgg16()
         >>> net.load_weights('./model_graph.h5', in_order=False, skip=True) # load weights by name, skipping mismatch
         >>> net.load_weights('./model_eager.h5') # load sequentially
 

--- a/tests/models/test_model_core.py
+++ b/tests/models/test_model_core.py
@@ -359,6 +359,34 @@ class Model_Core_Test(CustomTestCase):
         self.assertGreater(len(weights), 2)
         print(len(weights))
 
+    def test_get_layer(self):
+        print('-' * 20, 'test_get_layer', '-' * 20)
+        model_basic = basic_dynamic_model()
+        self.assertIsInstance(model_basic.get_layer('conv2'), tl.layers.Conv2d)
+        try:
+            model_basic.get_layer('abc')
+        except Exception as e:
+            print(e)
+
+        try:
+            model_basic.get_layer(index=99)
+        except Exception as e:
+            print(e)
+
+        model_basic = basic_static_model()
+        self.assertIsInstance(model_basic.get_layer('conv2'), tl.layers.Conv2d)
+        self.assertIsInstance(model_basic.get_layer(index=2), tl.layers.MaxPool2d)
+        print([w.name for w in model_basic.get_layer(index=-1).weights])
+        try:
+            model_basic.get_layer('abc')
+        except Exception as e:
+            print(e)
+
+        try:
+            model_basic.get_layer(index=99)
+        except Exception as e:
+            print(e)
+
 if __name__ == '__main__':
 
     unittest.main()

--- a/tests/models/test_model_core.py
+++ b/tests/models/test_model_core.py
@@ -25,13 +25,13 @@ def basic_static_model():
     nn = Flatten(name='flatten')(nn)
     nn = Dense(100, act=None, name="dense1")(nn)
     nn = Dense(10, act=None, name="dense2")(nn)
-    M = Model(inputs=ni, outputs=nn, name='basic_static')
+    M = Model(inputs=ni, outputs=nn)
     return M
 
 
 class basic_dynamic_model(Model):
     def __init__(self):
-        super(basic_dynamic_model, self).__init__(name="basic_dynamic")
+        super(basic_dynamic_model, self).__init__()
         self.conv1 = Conv2d(16, (5, 5), (1, 1), padding='SAME', act=tf.nn.relu, in_channels=3, name="conv1")
         self.pool1 = MaxPool2d((3, 3), (2, 2), padding='SAME', name='pool1')
 
@@ -74,7 +74,7 @@ class Model_Core_Test(CustomTestCase):
         self.assertEqual(model_basic._outputs, None)
         self.assertEqual(model_basic._model_layer, None)
         self.assertEqual(model_basic._all_layers, None)
-        self.assertEqual(model_basic._layer_node_fixed, False)
+        self.assertEqual(model_basic._nodes_fixed, False)
 
         # test layer and weights access
         all_layers = model_basic.all_layers
@@ -110,7 +110,7 @@ class Model_Core_Test(CustomTestCase):
         # test forwarding
         inputs = np.random.normal(size=[2, 24, 24, 3]).astype(np.float32)
         outputs1 = model_basic(inputs)
-        self.assertEqual(model_basic._layer_node_fixed, True)
+        self.assertEqual(model_basic._nodes_fixed, True)
         self.assertEqual(model_basic.is_train, False)
 
         try:
@@ -143,7 +143,7 @@ class Model_Core_Test(CustomTestCase):
         self.assertIsNotNone(model_basic._outputs)
         self.assertEqual(model_basic._model_layer, None)
         self.assertIsNotNone(model_basic._all_layers)
-        self.assertIsNotNone(model_basic._layer_node_fixed)
+        self.assertIsNotNone(model_basic._nodes_fixed)
 
         # test layer and weights access
         all_layers = model_basic.all_layers
@@ -176,7 +176,7 @@ class Model_Core_Test(CustomTestCase):
         # test forwarding
         inputs = np.random.normal(size=[2, 24, 24, 3]).astype(np.float32)
         outputs1 = model_basic(inputs)
-        self.assertEqual(model_basic._layer_node_fixed, True)
+        self.assertEqual(model_basic._nodes_fixed, True)
         self.assertEqual(model_basic.is_train, False)
 
         try:
@@ -195,86 +195,6 @@ class Model_Core_Test(CustomTestCase):
         # test release_memory
         try:
             model_basic.release_memory()
-        except Exception as e:
-            print(e)
-
-    def test_save_weights(self):
-        print('-' * 20, 'test save weights', '-' * 20)
-        def process(model_basic):
-            # Default save
-            model_basic.save_weights('./model_basic.none')
-
-            # hdf5
-            print('testing hdf5 saving...')
-            modify_val = np.zeros_like(model_basic.weights[-2].numpy())
-            ori_val = model_basic.weights[-2].numpy()
-            model_basic.save_weights("./model_basic.h5")
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.h5")
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.h5", format="hdf5")
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.h5", format="hdf5", in_order=False)
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-
-            ori_weights = model_basic._weights
-            model_basic._weights = model_basic._weights[1:]
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.h5", skip=True)
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-            model_basic._weights = ori_weights
-
-            # npz
-            print('testing npz saving...')
-            model_basic.save_weights("./model_basic.npz", format='npz')
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.npz")
-
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.npz", format='npz')
-            model_basic.save_weights("./model_basic.npz")
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-
-            # npz_dict
-            print('testing npz_dict saving...')
-            model_basic.save_weights("./model_basic.npz", format='npz_dict')
-            model_basic.weights[-2].assign(modify_val)
-            model_basic.load_weights("./model_basic.npz", format='npz_dict')
-            self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
-
-            # ckpt
-            try:
-                model_basic.save_weights('./model_basic.ckpt', format='ckpt')
-            except Exception as e:
-                self.assertIsInstance(e, NotImplementedError)
-
-            # other cases
-            try:
-                model_basic.save_weights('./model_basic.xyz', format='xyz')
-            except Exception as e:
-                self.assertIsInstance(e, ValueError)
-            try:
-                model_basic.load_weights('./model_basic.xyz', format='xyz')
-            except Exception as e:
-                self.assertIsInstance(e, FileNotFoundError)
-            try:
-                model_basic.load_weights('./model_basic.h5', format='xyz')
-            except Exception as e:
-                self.assertIsInstance(e, ValueError)
-
-        dynamic_basic = basic_dynamic_model()
-        process(dynamic_basic)
-        static_basic = basic_static_model()
-        process(static_basic)
-
-        print('testing save dynamic and load static...')
-        try:
-            dynamic_basic.save_weights("./model_basic.h5")
-            static_basic.load_weights("./model_basic.h5", in_order=False)
         except Exception as e:
             print(e)
 
@@ -352,7 +272,7 @@ class Model_Core_Test(CustomTestCase):
         try:
             class ill_model(Model):
                 def __init__(self):
-                    super(ill_model, self).__init__(name="basic_dynamic")
+                    super(ill_model, self).__init__()
                     self.dense2 = Dense(10, act=None)
 
                 def forward(self, x):

--- a/tests/models/test_model_save.py
+++ b/tests/models/test_model_save.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import unittest
+
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+
+import numpy as np
+import tensorflow as tf
+import tensorlayer as tl
+from tensorlayer.layers import *
+from tensorlayer.models import *
+
+from tests.utils import CustomTestCase
+
+
+def basic_static_model(include_top=True):
+    ni = Input((None, 24, 24, 3))
+    nn = Conv2d(16, (5, 5), (1, 1), padding='SAME', act=tf.nn.relu, name="conv1")(ni)
+    nn = MaxPool2d((3, 3), (2, 2), padding='SAME', name='pool1')(nn)
+
+    nn = Conv2d(16, (5, 5), (1, 1), padding='SAME', act=tf.nn.relu, name="conv2")(nn)
+    nn = MaxPool2d((3, 3), (2, 2), padding='SAME', name='pool2')(nn)
+
+    nn = Flatten(name='flatten')(nn)
+    nn = Dense(100, act=None, name="dense1")(nn)
+    if include_top is True:
+        nn = Dense(10, act=None, name="dense2")(nn)
+    M = Model(inputs=ni, outputs=nn)
+    return M
+
+
+class basic_dynamic_model(Model):
+    def __init__(self, include_top=True):
+        super(basic_dynamic_model, self).__init__()
+        self.include_top = include_top
+        self.conv1 = Conv2d(16, (5, 5), (1, 1), padding='SAME', act=tf.nn.relu, in_channels=3, name="conv1")
+        self.pool1 = MaxPool2d((3, 3), (2, 2), padding='SAME', name='pool1')
+
+        self.conv2 = Conv2d(16, (5, 5), (1, 1), padding='SAME', act=tf.nn.relu, in_channels=16, name="conv2")
+        self.pool2 = MaxPool2d((3, 3), (2, 2), padding='SAME', name='pool2')
+
+        self.flatten = Flatten(name='flatten')
+        self.dense1 = Dense(100, act=None, in_channels=576, name="dense1")
+        if include_top is True:
+            self.dense2 = Dense(10, act=None, in_channels=100, name="dense2")
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.pool1(x)
+        x = self.conv2(x)
+        x = self.pool2(x)
+        x = self.flatten(x)
+        x = self.dense1(x)
+        if self.include_top:
+            x = self.dense2(x)
+        return x
+
+
+class Nested_VGG(Model):
+    def __init__(self):
+        super(Nested_VGG, self).__init__()
+        self.vgg1 = tl.models.vgg16()
+        self.vgg2 = tl.models.vgg16()
+
+    def forward(self, x):
+        pass
+
+
+class Model_Save_Test(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.static_basic = basic_static_model()
+        cls.dynamic_basic = basic_dynamic_model()
+        cls.static_basic_skip = basic_static_model(include_top=False)
+        cls.dynamic_basic_skip = basic_dynamic_model(include_top=False)
+
+        print([l.name for l in cls.dynamic_basic.all_layers])
+        print([l.name for l in cls.dynamic_basic_skip.all_layers])
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def normal_save(self, model_basic):
+        # Default save
+        model_basic.save_weights('./model_basic.none')
+
+        # hdf5
+        print('testing hdf5 saving...')
+        modify_val = np.zeros_like(model_basic.weights[-2].numpy())
+        ori_val = model_basic.weights[-2].numpy()
+        model_basic.save_weights("./model_basic.h5")
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.h5")
+        self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
+
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.h5", format="hdf5")
+        self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
+
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.h5", format="hdf5", in_order=False)
+        self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
+
+        # npz
+        print('testing npz saving...')
+        model_basic.save_weights("./model_basic.npz", format='npz')
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.npz")
+
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.npz", format='npz')
+        model_basic.save_weights("./model_basic.npz")
+        self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
+
+        # npz_dict
+        print('testing npz_dict saving...')
+        model_basic.save_weights("./model_basic.npz", format='npz_dict')
+        model_basic.weights[-2].assign(modify_val)
+        model_basic.load_weights("./model_basic.npz", format='npz_dict')
+        self.assertLess(np.max(np.abs(ori_val - model_basic.weights[-2].numpy())), 1e-7)
+
+        # ckpt
+        try:
+            model_basic.save_weights('./model_basic.ckpt', format='ckpt')
+        except Exception as e:
+            self.assertIsInstance(e, NotImplementedError)
+
+        # other cases
+        try:
+            model_basic.save_weights('./model_basic.xyz', format='xyz')
+        except Exception as e:
+            self.assertIsInstance(e, ValueError)
+        try:
+            model_basic.load_weights('./model_basic.xyz', format='xyz')
+        except Exception as e:
+            self.assertIsInstance(e, FileNotFoundError)
+        try:
+            model_basic.load_weights('./model_basic.h5', format='xyz')
+        except Exception as e:
+            self.assertIsInstance(e, ValueError)
+
+    def test_normal_save(self):
+        print('-' * 20, 'test save weights', '-' * 20)
+
+        self.normal_save(self.static_basic)
+        self.normal_save(self.dynamic_basic)
+
+        print('testing save dynamic and load static...')
+        try:
+            self.dynamic_basic.save_weights("./model_basic.h5")
+            self.static_basic.load_weights("./model_basic.h5", in_order=False)
+        except Exception as e:
+            print(e)
+
+    def test_skip(self):
+        print('-' * 20, 'test skip save/load', '-' * 20)
+
+        print("testing dynamic skip load...")
+        self.dynamic_basic.save_weights("./model_basic.h5")
+        ori_weights = self.dynamic_basic_skip.weights
+        ori_val = ori_weights[1].numpy()
+        modify_val = np.zeros_like(ori_val)
+        self.dynamic_basic_skip.weights[1].assign(modify_val)
+        self.dynamic_basic_skip.load_weights("./model_basic.h5", skip=True)
+        self.assertLess(np.max(np.abs(ori_val - self.dynamic_basic_skip.weights[1].numpy())), 1e-7)
+
+        print("testing static skip load...")
+        self.static_basic.save_weights("./model_basic.h5")
+        ori_weights = self.static_basic_skip.weights
+        ori_val = ori_weights[1].numpy()
+        modify_val = np.zeros_like(ori_val)
+        self.static_basic_skip.weights[1].assign(modify_val)
+        self.static_basic_skip.load_weights("./model_basic.h5", skip=True)
+        self.assertLess(np.max(np.abs(ori_val - self.static_basic_skip.weights[1].numpy())), 1e-7)
+
+    def test_nested_vgg(self):
+        print('-' * 20, 'test nested vgg', '-' * 20)
+        nested_vgg = Nested_VGG()
+        print([l.name for l in nested_vgg.all_layers])
+        nested_vgg.save_weights("nested_vgg.h5")
+
+        # modify vgg1 weight val
+        tar_weight1 = nested_vgg.vgg1.layers[0].weights[0]
+        print(tar_weight1.name)
+        ori_val1 = tar_weight1.numpy()
+        modify_val1 = np.zeros_like(ori_val1)
+        tar_weight1.assign(modify_val1)
+        # modify vgg2 weight val
+        tar_weight2 = nested_vgg.vgg2.layers[1].weights[0]
+        print(tar_weight2.name)
+        ori_val2 = tar_weight2.numpy()
+        modify_val2 = np.zeros_like(ori_val2)
+        tar_weight2.assign(modify_val2)
+
+        nested_vgg.load_weights("nested_vgg.h5")
+
+        self.assertLess(np.max(np.abs(ori_val1 - tar_weight1.numpy())), 1e-7)
+        self.assertLess(np.max(np.abs(ori_val2 - tar_weight2.numpy())), 1e-7)
+
+    # TODO : three level nesting is not supported now.
+    # def test_double_nested_vgg(self):
+    #     print('-' * 20, 'test_double_nested_vgg', '-' * 20)
+    #     class mymodel(Model):
+    #         def __init__(self):
+    #             super(mymodel, self).__init__()
+    #             self.inner = Nested_VGG()
+    #
+    #         def forward(self, *inputs, **kwargs):
+    #             pass
+    #
+    #     net = mymodel()
+    #     try:
+    #         net.save_weights("double_nested.h5")
+    #         net.load_weights("double_nested.h5")
+    #     except Exception as e:
+    #         print(e)
+
+    def test_exceptions(self):
+        print('-' * 20, 'test_exceptions', '-' * 20)
+        try:
+            ni = Input([4, 784])
+            model = Model(inputs=ni, outputs=ni)
+            model.save_weights('./empty_model.h5')
+        except Exception as e:
+            print(e)
+
+if __name__ == '__main__':
+
+    unittest.main()


### PR DESCRIPTION
### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
1) refactor model save/load to fit the new auto-naming scenario.
2) add get_layer method for Model, enabling quick accessing to a specific layer and its weights.

### Description
Methods are tested and doced. Here I want to point out some limitation currently:
1) model save/load can support nested model such as a model consisting of two VGG16s, but there will be error for double nested scenario, eg. model->inner_model -> 2VGGs. For this issue, it will take some time to fix it and it seems that Keras will also failed in this scenario(I will double check). 

2) get_layer will only consider the 'first level' layers --- those layers capsuled by model.all_layers. But I found this makes VGG usage a bit awkward as VGG maintains only a LayerList in first level.
