### PR TITLE
Simpler test file

### DIFF
--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -44,15 +44,12 @@ class Test_Leaky_ReLUs(CustomTestCase):
         words = tl.files.load_matt_mahoney_text8_dataset()
         vocabulary_size = 50000
         data, count, dictionary, reverse_dictionary = tl.nlp.build_words_dataset(words, vocabulary_size, True)
-        tl.nlp.save_vocab(count, name='vocab_text8.txt')        
+        tl.nlp.save_vocab(count, name='vocab_text8.txt')     
 
     def test_basic_tokenizer(self):
-        train_path = "wmt/giga-fren.release2"
-        with gfile.GFile(train_path + ".en", mode="rb") as f:
-           for line in f:
-              tokens = tl.nlp.basic_tokenizer(line)
-              tl.logging.info(tokens)
-              exit()
+        c = "how are you?"
+        tokens = tl.nlp.basic_tokenizer(c)
+        print(tokens)
 
     def test_generate_skip_gram_batch(self):
         data = [1,2,3,4,5,6,7,8,9,10,11]


### PR DESCRIPTION
…est_save_vocab

<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
Update nlp_test.
And part of the vocab_text8.txt content (generated while testing):
UNK 418391
the 1061396
of 593677
and 416629
one 411764
in 372201
a 325873
to 316376
zero 264975
nine 250430
two 192644
is 183153
as 131815
eight 125285
for 118445
s 116710
five 115789
three 114775
was 112807
by 111831
that 109510
four 108182
six 102145
seven 99683
with 95603
on 91250
are 76527
it 73334
from 72871
or 68945