### PR TITLE
fix dynamic model cannot track PRelu weights gradients problem

### DIFF
--- a/tensorlayer/layers/activation.py
+++ b/tensorlayer/layers/activation.py
@@ -95,6 +95,7 @@ class PRelu(Layer):
     def forward(self, inputs):
 
         pos = tf.nn.relu(inputs)
+        self.alpha_var_constrained = tf.nn.sigmoid(self.alpha_var, name="constraining_alpha_var_in_0_1")
         neg = -self.alpha_var_constrained * tf.nn.relu(-inputs)
 
         return pos + neg


### PR DESCRIPTION
<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
In dynamic mode, gradients do not exist for PRelu layer weights.
Test in test_layers_activation.py passed.

### Description
Calculations including weights of PRelu layer must be done in the model's forward() function.